### PR TITLE
Clarify config settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,20 @@ You can install the package in to a Laravel app that uses [Nova](https://nova.la
 composer require honeybadger-io/nova-honeybadger
 ```
 
-Next, define your Honeybadger Project ID and API key inside your `config/services.php` file, like this:
+Next, define your Honeybadger Project ID and [Authentication Token](https://docs.honeybadger.io/api/data.html) inside your `config/services.php` file, like this:
 
 ```php
 'honeybadger' => [
-    'api_key' => env('HONEYBADGER_API_KEY'),
-    'project_id' => env('HONEYBADGER_PROJECT')
+    'auth_token' => env('HONEYBADGER_AUTH_TOKEN'),
+    'project_id' => env('HONEYBADGER_PROJECT_ID')
 ]
 ```
+
+You can get your Project ID from the URL of your Honeybadger project:
+
+https://app.honeybadger.io/projects/[ID]/faults
+
+Your Authentication Token is available on [your Honeybadger profile page](https://app.honeybadger.io/users/edit) (Note: this is different from your project's API key).
 
 ## Usage
 

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -54,7 +54,7 @@ class ToolServiceProvider extends ServiceProvider
             $client = new Client([
                 'base_uri' => Api::API_URL,
                 'verify' => false,
-                'auth' => [config('services.honeybadger.api_key'), '']
+                'auth' => [config('services.honeybadger.auth_token'), '']
             ]);
 
             return new Api($client);


### PR DESCRIPTION
I accidentally renamed the original "token" config setting to "api_key",
which is wrong; this setting is for the data API, which is available on
the user settings page. "token" was more accurate, but I still found it
confusing, so I decided on "auth_token" to better clarify the
difference.